### PR TITLE
Corrected links to episode pages

### DIFF
--- a/iguana/podcast.twig
+++ b/iguana/podcast.twig
@@ -8,12 +8,12 @@
         {% for episode in episodes %}
             <li class="episodes">
                 <div class="episode-image">
-                    <a href="{{ base_url }}/episode/{{ episode.address }}">
+                    <a href="{{ episode.address }}">
                     <img src="{{ base_url }}/assets/image/{{ episode.thumbnailImage }}" width="150" height="150">
                     </a>
                 </div>
                 <div class="episode-text">
-                    <a href="{{ base_url }}/episode/{{ episode.address }}">
+                    <a href="{{ episode.address }}">
                         <h3>{{ episode.title }}</h3>
                     </a>
                     {{ episode.excerpt }}


### PR DESCRIPTION
Page metadata comes with the full URL, so there's no need to prefix with the base URL
